### PR TITLE
Fixed color reset issue

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -94,7 +94,7 @@ __git_ps1 ()
 {
     if [ "$(git config --bool bash.enableGitStatus)" == "false" ]; then return; fi
 
-    local DefaultForegroundColor='\e[0;30m' # Default no color
+    local DefaultForegroundColor='\e[m' # Default no color
     local DefaultBackgroundColor=
 
     local BeforeText=' ['


### PR DESCRIPTION
In line [97](https://github.com/lyze/posh-git-bash/blob/4657f74339a234834076ad2646ed365d6215c16d/git-prompt.sh#L97) of the script, the `DefaultForegroundColor` is defined as `\e[0;30m`, which sets the color to black, rather than the color it was using before. In a shell that uses black as its background color, this means everything after the first successful display from posh-git-bash will be nigh-impossible to read.

In my local copy of the script, I've changed it to use `\e[m`, which resets the color scheme. Passing this back upstream to benefit anyone else who uses it.
