### PR TITLE
Fixed working directory/index mismatch

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -275,7 +275,7 @@ __git_ps1 ()
         local filesModified=0
         local filesDeleted=0
         local filesUnmerged=0
-        while IFS=" " read -r tag rest
+        while IFS="\n" read -r tag rest
         do
             case "${tag:0:1}" in
                 A )


### PR DESCRIPTION
Hi again!
Given a working directory where the following changes have been made per `git status -sb`:

```
## master
M  1_index_modified.md
D  2_index_deleted.md
 M 3_modified.md
 D 4_deleted.md
A  5_index_new.md
?? 6_new.md
```

and utilizing posh-git-sh via `PROMPT_COMMAND='__git_ps1 "\u@\h:\w" "\\\$ "'` in ~/.bashrc, the following branch information is shown:

```
[master +1 ~2 -2 | +2 ~0 -0]
```

versus the expected:

```
[master +1 ~1 -1 | +1 ~1 -1]
```

Because `git status -s` puts the status for the working directory in a second column, filling the first with a space if the given file has no indexed changes yet, parsing out the index status incorrectly includes some working directory changes.

On my machine, replacing `IFS=" "` with `IFS="\n"` solves this. Pull request to match. Please try the change in your environment before accepting; it works for me on OS X 10.8 and Arch Linux, but I haven't tried it anywhere else, so YMMV.
