### PR TITLE
Removes trailing space after git string

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -367,7 +367,7 @@ __git_ps1 ()
     if $ShowStashState; then
         gitstring+="\[$StashBackgroundColor\]\[$StashForegroundColor\]"$StashText
     fi
-    gitstring=`printf -- "$printf_format" "$gitstring\[$DefaultBackgroundColor\]\[$DefaultForegroundColor\] "`
+    gitstring=`printf -- "$printf_format" "$gitstring\[$DefaultBackgroundColor\]\[$DefaultForegroundColor\]"`
     if $is_pcmode; then
         PS1="$ps1pc_start$gitstring$ps1pc_end"
     else


### PR DESCRIPTION
Hi,

I believe this adds flexibility to the way the PS1 string is formatted. For example, previously I could not have the following two prompts - one outside a repo and one inside.

```
/some/directory :
/some/directory/repo [master] :
```

As a space is always added after the git string, I could use either of the following and get one of the above working but not the other:

```
PROMPT_COMMAND='__git_ps1 "\w" ": "'
PROMPT_COMMAND='__git_ps1 "\w" " : "'
```

With this change you can use the latter and prompts inside and outside a repo would be consistent.

Regards
