### PR TITLE
docs: Added additional documentation relevant to mac users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ it. Please do not hesitate to contact me about any issues or requests.
 Installation Instructions
 =========================
 1. Copy this file to somewhere (e.g. `~/git-prompt.sh`).
-2. Add the following line to your `.bashrc`:
+2. Add the following line to your `.bashrc` for most version of linux and unix, however if you are using a MAC your changes need to be in ~/.bash_profile:
 
         source ~/git-prompt.sh
 


### PR DESCRIPTION
I kept running into a problem with new mac users using your install
instructions and wondering why they could not get it to work only
to tell them that /.bashrc does not work on mac they need to use
either ~/.bash_profile, ~/.bash_login, and ~/.profile