### PR TITLE
Added branch status symbols like new poshgit

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ it. Please do not hesitate to contact me about any issues or requests.
 Installation Instructions
 =========================
 1. Copy this file to somewhere (e.g. `~/git-prompt.sh`).
-2. Add the following line to your `.bashrc` for most version of linux and unix, however if you are using a MAC your changes need to be in ~/.bash_profile:
+2. Add the following line to your `~/.bashrc`. (You may need to update
+   your `~/.bash_profile` to source your `~/.bashrc`, or you can just modify
+   `~/.bash_profile` directly.)
 
         source ~/git-prompt.sh
 

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -143,6 +143,11 @@ __posh_git_ps1 ()
     local AfterForegroundColor='\e[1;33m' # Yellow
     local AfterBackgroundColor=
 
+    local BranchIdenticalStatusToSymbol=$'\xE2\x89\xA1' # Three horizontal lines
+    local BranchAheadStatusSymbol=$'\xE2\x86\x91' # Up Arrow
+    local BranchBehindStatusSymbol=$'\xE2\x86\x93' # Down Arrow
+    local BranchBehindAndAheadStatusSymbol=$'\xE2\x86\x95' # Up and Down Arrow
+
     local BranchForegroundColor='\e[1;36m' # Cyan
     local BranchBackgroundColor=
     local BranchAheadForegroundColor='\e[1;32m' # Green
@@ -352,19 +357,20 @@ __posh_git_ps1 ()
 
     local gitstring=
     local branchstring="$isBare${b##refs/heads/}"
+
     # before-branch text
     gitstring="\[$BeforeBackgroundColor\]\[$BeforeForegroundColor\]$BeforeText"
 
     # branch
 
     if (( $behindBy > 0 && $aheadBy > 0 )); then
-        gitstring+="\[$BranchBehindAndAheadBackgroundColor\]\[$BranchBehindAndAheadForegroundColor\]$branchstring"
+        gitstring+="\[$BranchBehindAndAheadBackgroundColor\]\[$BranchBehindAndAheadForegroundColor\]$branchstring $BranchBehindAndAheadStatusSymbol"
     elif (( $behindBy > 0 )); then
-        gitstring+="\[$BranchBehindBackgroundColor\]\[$BranchBehindForegroundColor\]$branchstring"
+        gitstring+="\[$BranchBehindBackgroundColor\]\[$BranchBehindForegroundColor\]$branchstring $BranchBehindStatusSymbol"
     elif (( $aheadBy > 0 )); then
-        gitstring+="\[$BranchAheadBackgroundColor\]\[$BranchAheadForegroundColor\]$branchstring"
+        gitstring+="\[$BranchAheadBackgroundColor\]\[$BranchAheadForegroundColor\]$branchstring $BranchAheadStatusSymbol"
     else
-        gitstring+="\[$BranchBackgroundColor\]\[$BranchForegroundColor\]$branchstring"
+        gitstring+="\[$BranchBackgroundColor\]\[$BranchForegroundColor\]$branchstring $BranchIdenticalStatusToSymbol"
     fi
 
     local indexCount="$(( $indexAdded + $indexModified + $indexDeleted + $indexUnmerged ))"


### PR DESCRIPTION
I added unicode symbols showing the branch status, like the recent versions of posh-git on PS. Unicode encoded as 3byte hex. Haven't tested if it works in zsh but it works in BASH.