### PR TITLE
Added symbols for branch status like PS version

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -143,6 +143,11 @@ __posh_git_ps1 ()
     local AfterForegroundColor='\e[1;33m' # Yellow
     local AfterBackgroundColor=
 
+    local BranchIdenticalStatusToSymbol=$'\xE2\x89\xA1' # Three horizontal lines
+    local BranchAheadStatusSymbol=$'\xE2\x86\x91' # Up Arrow
+    local BranchBehindStatusSymbol=$'\xE2\x86\x93' # Down Arrow
+    local BranchBehindAndAheadStatusSymbol=$'\xE2\x86\x95' # Up and Down Arrow
+
     local BranchForegroundColor='\e[1;36m' # Cyan
     local BranchBackgroundColor=
     local BranchAheadForegroundColor='\e[1;32m' # Green
@@ -352,19 +357,20 @@ __posh_git_ps1 ()
 
     local gitstring=
     local branchstring="$isBare${b##refs/heads/}"
+
     # before-branch text
     gitstring="\[$BeforeBackgroundColor\]\[$BeforeForegroundColor\]$BeforeText"
 
     # branch
 
     if (( $behindBy > 0 && $aheadBy > 0 )); then
-        gitstring+="\[$BranchBehindAndAheadBackgroundColor\]\[$BranchBehindAndAheadForegroundColor\]$branchstring"
+        gitstring+="\[$BranchBehindAndAheadBackgroundColor\]\[$BranchBehindAndAheadForegroundColor\]$branchstring $BranchBehindAndAheadStatusSymbol"
     elif (( $behindBy > 0 )); then
-        gitstring+="\[$BranchBehindBackgroundColor\]\[$BranchBehindForegroundColor\]$branchstring"
+        gitstring+="\[$BranchBehindBackgroundColor\]\[$BranchBehindForegroundColor\]$branchstring $BranchBehindStatusSymbol"
     elif (( $aheadBy > 0 )); then
-        gitstring+="\[$BranchAheadBackgroundColor\]\[$BranchAheadForegroundColor\]$branchstring"
+        gitstring+="\[$BranchAheadBackgroundColor\]\[$BranchAheadForegroundColor\]$branchstring $BranchAheadStatusSymbol"
     else
-        gitstring+="\[$BranchBackgroundColor\]\[$BranchForegroundColor\]$branchstring"
+        gitstring+="\[$BranchBackgroundColor\]\[$BranchForegroundColor\]$branchstring $BranchIdenticalStatusToSymbol"
     fi
 
     local indexCount="$(( $indexAdded + $indexModified + $indexDeleted + $indexUnmerged ))"


### PR DESCRIPTION
Haven't tested with zsh. Works with bash. Unicode symbols encoded as three byte hex.