### PR TITLE
Configure status symbol visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Installation Instructions
     will show username, at-sign, host, colon, cwd, then various status strings,
     followed by dollar and space, as your prompt. This invocation prepends this
     instruction to the existing value of `PROMPT_COMMAND`.
-    
+
     If you are using `zsh`, you need to set the
     [`PROMPT`](http://zsh.sourceforge.net/Doc/Release/Parameters.html#index-PROMPT)
     variable or the
@@ -175,6 +175,13 @@ Option | Description
 legacy | Does not use the `--count` option available in recent versions of `git-rev-list`
 git    | _Default_. Always compares `HEAD` to `@{upstream}`
 svn    | Always compares `HEAD` to `SVN` upstream
+
+### bash.enableStatusSymbol
+
+Option | Description
+------ | -----------
+true   | _Default_. Status symbols (`≡` `↑` `↓` `↕`) will be shown.
+false  | No status symbol will be shown, saving some prompt length.
 
 
 Background

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -205,15 +205,15 @@ __posh_git_echo () {
         *)     EnableStatusSymbol=true ;;
     esac
 
-    local branchIdenticalStatusSymbol=''
-    local branchAheadStatusSymbol=''
-    local branchBehindStatusSymbol=''
-    local branchBehindAndAheadStatusSymbol=''
+    local BranchIdenticalStatusSymbol=''
+    local BranchAheadStatusSymbol=''
+    local BranchBehindStatusSymbol=''
+    local BranchBehindAndAheadStatusSymbol=''
     if $EnableStatusSymbol; then
-      branchIdenticalStatusSymbol=$' \xE2\x89\xA1' # Three horizontal lines
-      branchAheadStatusSymbol=$' \xE2\x86\x91' # Up Arrow
-      branchBehindStatusSymbol=$' \xE2\x86\x93' # Down Arrow
-      branchBehindAndAheadStatusSymbol=$' \xE2\x86\x95' # Up and Down Arrow
+      BranchIdenticalStatusSymbol=$' \xE2\x89\xA1' # Three horizontal lines
+      BranchAheadStatusSymbol=$' \xE2\x86\x91' # Up Arrow
+      BranchBehindStatusSymbol=$' \xE2\x86\x93' # Down Arrow
+      BranchBehindAndAheadStatusSymbol=$' \xE2\x86\x95' # Up and Down Arrow
     fi
 
     # these globals are updated by __posh_git_ps1_upstream_divergence
@@ -364,13 +364,13 @@ __posh_git_echo () {
 
     # branch
     if (( $__POSH_BRANCH_BEHIND_BY > 0 && $__POSH_BRANCH_AHEAD_BY > 0 )); then
-        gitstring+="$BranchBehindAndAheadBackgroundColor$BranchBehindAndAheadForegroundColor$branchstring$branchBehindAndAheadStatusSymbol"
+        gitstring+="$BranchBehindAndAheadBackgroundColor$BranchBehindAndAheadForegroundColor$branchstring$BranchBehindAndAheadStatusSymbol"
     elif (( $__POSH_BRANCH_BEHIND_BY > 0 )); then
-        gitstring+="$BranchBehindBackgroundColor$BranchBehindForegroundColor$branchstring$branchBehindStatusSymbol"
+        gitstring+="$BranchBehindBackgroundColor$BranchBehindForegroundColor$branchstring$BranchBehindStatusSymbol"
     elif (( $__POSH_BRANCH_AHEAD_BY > 0 )); then
-        gitstring+="$BranchAheadBackgroundColor$BranchAheadForegroundColor$branchstring$branchAheadStatusSymbol"
+        gitstring+="$BranchAheadBackgroundColor$BranchAheadForegroundColor$branchstring$BranchAheadStatusSymbol"
     else
-        gitstring+="$BranchBackgroundColor$BranchForegroundColor$branchstring$branchIdenticalStatusSymbol"
+        gitstring+="$BranchBackgroundColor$BranchForegroundColor$branchstring$BranchIdenticalStatusSymbol"
     fi
 
     # index status

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -90,6 +90,15 @@
 #          `git-rev-list`
 # git    | _Default_. Always compares `HEAD` to `@{upstream}`
 # svn    | Always compares `HEAD` to `SVN` upstream
+#
+# bash.enableStatusSymbol
+# -----------------------
+
+# Option | Description
+# ------ | -----------
+# true   | _Default_. Status symbols (`≡` `↑` `↓` `↕`) will be shown.
+# false  | No status symbol will be shown, saving some prompt length.
+#
 ###############################################################################
 
 # Convenience function to set PS1 to show git status. Must supply two
@@ -145,11 +154,6 @@ __posh_git_echo () {
     local AfterForegroundColor=$(__posh_color '\e[1;33m') # Yellow
     local AfterBackgroundColor=
 
-    local BranchIdenticalStatusToSymbol=$'\xE2\x89\xA1' # Three horizontal lines
-    local BranchAheadStatusSymbol=$'\xE2\x86\x91' # Up Arrow
-    local BranchBehindStatusSymbol=$'\xE2\x86\x93' # Down Arrow
-    local BranchBehindAndAheadStatusSymbol=$'\xE2\x86\x95' # Up and Down Arrow
-
     local BranchForegroundColor=$(__posh_color '\e[1;36m')  # Cyan
     local BranchBackgroundColor=
     local BranchAheadForegroundColor=$(__posh_color '\e[1;32m') # Green
@@ -194,6 +198,23 @@ __posh_git_echo () {
         false) ShowStashState=false ;;
         *)     ShowStashState=true ;;
     esac
+    local EnableStatusSymbol=`git config --bool bash.enableStatusSymbol`
+    case "$EnableStatusSymbol" in
+        true)  EnableStatusSymbol=true ;;
+        false) EnableStatusSymbol=false ;;
+        *)     EnableStatusSymbol=true ;;
+    esac
+
+    local branchIdenticalStatusSymbol=''
+    local branchAheadStatusSymbol=''
+    local branchBehindStatusSymbol=''
+    local branchBehindAndAheadStatusSymbol=''
+    if $EnableStatusSymbol; then
+      branchIdenticalStatusSymbol=$' \xE2\x89\xA1' # Three horizontal lines
+      branchAheadStatusSymbol=$' \xE2\x86\x91' # Up Arrow
+      branchBehindStatusSymbol=$' \xE2\x86\x93' # Down Arrow
+      branchBehindAndAheadStatusSymbol=$' \xE2\x86\x95' # Up and Down Arrow
+    fi
 
     # these globals are updated by __posh_git_ps1_upstream_divergence
     __POSH_BRANCH_AHEAD_BY=0
@@ -343,13 +364,13 @@ __posh_git_echo () {
 
     # branch
     if (( $__POSH_BRANCH_BEHIND_BY > 0 && $__POSH_BRANCH_AHEAD_BY > 0 )); then
-        gitstring+="$BranchBehindAndAheadBackgroundColor$BranchBehindAndAheadForegroundColor$branchstring $BranchBehindAndAheadStatusSymbol"
+        gitstring+="$BranchBehindAndAheadBackgroundColor$BranchBehindAndAheadForegroundColor$branchstring$branchBehindAndAheadStatusSymbol"
     elif (( $__POSH_BRANCH_BEHIND_BY > 0 )); then
-        gitstring+="$BranchBehindBackgroundColor$BranchBehindForegroundColor$branchstring $BranchBehindStatusSymbol"
+        gitstring+="$BranchBehindBackgroundColor$BranchBehindForegroundColor$branchstring$branchBehindStatusSymbol"
     elif (( $__POSH_BRANCH_AHEAD_BY > 0 )); then
-        gitstring+="$BranchAheadBackgroundColor$BranchAheadForegroundColor$branchstring $BranchAheadStatusSymbol"
+        gitstring+="$BranchAheadBackgroundColor$BranchAheadForegroundColor$branchstring$branchAheadStatusSymbol"
     else
-        gitstring+="$BranchBackgroundColor$BranchForegroundColor$branchstring $BranchIdenticalStatusToSymbol"
+        gitstring+="$BranchBackgroundColor$BranchForegroundColor$branchstring$branchIdenticalStatusSymbol"
     fi
 
     # index status


### PR DESCRIPTION
Added new config option `bash.enableStatusSymbol` to show/hide the branch status symbol. Default is true, i.e. visible.

Haven't tested with zsh