### PR TITLE
Solves Issue #22

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Installation Instructions
     hook. See also `__posh_git_echo` or
     [issue #14 for `oh-my-zsh`](https://github.com/lyze/posh-git-sh/issues/14).
 
+    If you are using conda, and want to keep the environment name information prepended to the system promt use the following in your .bashrc fiel
+
+    ```sh
+    PROMPT_COMMAND='__posh_git_ps1 "$PS1" "";'$PROMPT_COMMAND
+    ```
+
 
 The Prompt
 ----------

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -120,6 +120,10 @@ __posh_git_ps1 ()
             ;;
     esac
     local gitstring=$(__posh_git_echo)
+	#same as: removing everything after   $BeforeBackgroundColor$BeforeForegroundColor$BeforeText 
+	ps1pc_prefix="${ps1pc_prefix%%'\[\e[1;33m\] ['*}"
+	#same as: removing everything before  $AfterBackgroundColor$AfterForegroundColor$AfterText 
+	ps1pc_suffix="${ps1pc_suffix##*'\[\e[1;33m\]]'*}"
     PS1=$ps1pc_prefix$gitstring$ps1pc_suffix
 }
 


### PR DESCRIPTION
Adds compatibility between posh-git-sh and conda, so it's possible to display information about the conda environment and the Git status at the same time. This fix is backwards compatible.
Before:
```sh
user@linux ~/repo [master ≡] $
user@linux ~/repo [master ≡] $ source activate test-environment
user@linux ~/repo [master ≡] $
```
Now:
```sh
user@linux ~/repo $ [master ≡]  
user@linux ~/repo $ [master ≡]  source activate test-environment
(test-environment) user@linux ~/repo $ [master ≡] 
```
Using 
```
PROMPT_COMMAND='__posh_git_ps1 "$PS1" "";'$PROMPT_COMMAND
```
in .bashrc file
