### PR TITLE
Removed space in `BeforeText`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Installation Instructions
     This function updates `PS1` accordingly. For example, the following
 
     ```sh
-    PROMPT_COMMAND='__posh_git_ps1 "\u@\h:\w" "\\\$ ";'$PROMPT_COMMAND
+    PROMPT_COMMAND='__posh_git_ps1 "\u@\h:\w " "\\\$ ";'$PROMPT_COMMAND
     ```
 
     will show username, at-sign, host, colon, cwd, then various status strings,

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -143,7 +143,7 @@ __posh_git_echo () {
     local DefaultForegroundColor=$(__posh_color '\e[m') # Default no color
     local DefaultBackgroundColor=
 
-    local BeforeText=' ['
+    local BeforeText='['
     local BeforeForegroundColor=$(__posh_color '\e[1;33m') # Yellow
     local BeforeBackgroundColor=
     local DelimText=' |'


### PR DESCRIPTION
If people want to add space to `BeforeText`, they can add this by adding it to the prefix they passed in.