### PR TITLE
Added a stash symbol separator and fixed the stash indicator position

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -420,15 +420,16 @@ __posh_git_echo () {
     fi
     gitstring+="${rebase:+$RebaseForegroundColor$RebaseBackgroundColor$rebase}"
 
-    # after-branch text
-    gitstring+="$AfterBackgroundColor$AfterForegroundColor$AfterText"
-
     if $ShowStashState && $hasStash; then
-        gitstring+="$StashBackgroundColor$StashForegroundColor"$StashText
+        gitstring+="$DelimBackgroundColor$DelimForegroundColor$DelimText$StashBackgroundColor$StashForegroundColor"$StashText
         if $ShowStashCount; then
             gitstring+=$stashCount
         fi
     fi
+
+    # after-branch text
+    gitstring+="$AfterBackgroundColor$AfterForegroundColor$AfterText"
+
     gitstring+="$DefaultBackgroundColor$DefaultForegroundColor"
     echo "$gitstring"
 }


### PR DESCRIPTION
This PR changes the prompt from this

![screenshot from 2018-12-17 11-30-34](https://user-images.githubusercontent.com/10473142/50069269-42245680-01ef-11e9-881d-52a26b567a05.png)

TO

![screenshot from 2018-12-17 11-30-11](https://user-images.githubusercontent.com/10473142/50069268-418bc000-01ef-11e9-984c-43d8c01a9162.png)
