### PR TITLE
Show ahead/behind counts

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -228,7 +228,7 @@ __posh_git_echo () {
       BranchIdenticalStatusSymbol=$' \xE2\x89\xA1' # Three horizontal lines
       BranchAheadStatusSymbol=$' \xE2\x86\x91' # Up Arrow
       BranchBehindStatusSymbol=$' \xE2\x86\x93' # Down Arrow
-      BranchBehindAndAheadStatusSymbol=$' \xE2\x86\x95' # Up and Down Arrow
+      BranchBehindAndAheadStatusSymbol=$'\xE2\x86\x95' # Up and Down Arrow
       BranchWarningStatusSymbol=' ?'
     fi
 
@@ -385,11 +385,11 @@ __posh_git_echo () {
 
     # branch
     if (( $__POSH_BRANCH_BEHIND_BY > 0 && $__POSH_BRANCH_AHEAD_BY > 0 )); then
-        gitstring+="$BranchBehindAndAheadBackgroundColor$BranchBehindAndAheadForegroundColor$branchstring$BranchBehindAndAheadStatusSymbol"
+        gitstring+="$BranchBehindAndAheadBackgroundColor$BranchBehindAndAheadForegroundColor$branchstring $__POSH_BRANCH_BEHIND_BY$BranchBehindAndAheadStatusSymbol$__POSH_BRANCH_AHEAD_BY"
     elif (( $__POSH_BRANCH_BEHIND_BY > 0 )); then
-        gitstring+="$BranchBehindBackgroundColor$BranchBehindForegroundColor$branchstring$BranchBehindStatusSymbol"
+        gitstring+="$BranchBehindBackgroundColor$BranchBehindForegroundColor$branchstring$BranchBehindStatusSymbol$__POSH_BRANCH_BEHIND_BY"
     elif (( $__POSH_BRANCH_AHEAD_BY > 0 )); then
-        gitstring+="$BranchAheadBackgroundColor$BranchAheadForegroundColor$branchstring$BranchAheadStatusSymbol"
+        gitstring+="$BranchAheadBackgroundColor$BranchAheadForegroundColor$branchstring$BranchAheadStatusSymbol$__POSH_BRANCH_AHEAD_BY"
     elif (( $divergence_return_code )); then
         # ahead and behind are both 0, but there was some problem while executing the command.
         gitstring+="$BranchBackgroundColor$BranchForegroundColor$branchstring$BranchWarningStatusSymbol"

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -41,8 +41,7 @@
 # compact  | Display count alongside the appropriate up/down arrow. If both
 #          | behind and ahead, display the behind count, then a double arrow,
 #          | then the ahead count.
-# minimal  | Do not display counts or arrows; only the color of the branch name
-#          | will indicate the behind/ahead status.
+# minimal  | Display the up/down or double arrow as appropriate, with no counts.
 #
 # bash.describeStyle
 # ------------------
@@ -412,16 +411,22 @@ __posh_git_echo () {
             gitstring+="$BranchBehindStatusSymbol$__POSH_BRANCH_BEHIND_BY$BranchAheadStatusSymbol$__POSH_BRANCH_AHEAD_BY"
         elif [ "$BranchBehindAndAheadDisplay" = "compact" ]; then
             gitstring+=" $__POSH_BRANCH_BEHIND_BY$BranchBehindAndAheadStatusSymbol$__POSH_BRANCH_AHEAD_BY"
+        else
+            gitstring+=" $BranchBehindAndAheadStatusSymbol"
         fi
     elif (( $__POSH_BRANCH_BEHIND_BY > 0 )); then
         gitstring+="$BranchBehindBackgroundColor$BranchBehindForegroundColor$branchstring"
         if [ "$BranchBehindAndAheadDisplay" = "full" -o "$BranchBehindAndAheadDisplay" = "compact" ]; then
             gitstring+="$BranchBehindStatusSymbol$__POSH_BRANCH_BEHIND_BY"
+        else
+            gitstring+="$BranchBehindStatusSymbol"
         fi
     elif (( $__POSH_BRANCH_AHEAD_BY > 0 )); then
         gitstring+="$BranchAheadBackgroundColor$BranchAheadForegroundColor$branchstring"
         if [ "$BranchBehindAndAheadDisplay" = "full" -o "$BranchBehindAndAheadDisplay" = "compact" ]; then
             gitstring+="$BranchAheadStatusSymbol$__POSH_BRANCH_AHEAD_BY"
+        else
+            gitstring+="$BranchAheadStatusSymbol"
         fi
     elif (( $divergence_return_code )); then
         # ahead and behind are both 0, but there was some problem while executing the command.


### PR DESCRIPTION
Fixes #31.

This differs from the default behavior of [dahlbyk/posh-git](https://github.com/dahlbyk/posh-git) in that it still uses the combined ahead/behind arrow, whereas `posh-git` now uses two separate arrows unless [BranchBehindAndAheadDisplay](https://github.com/dahlbyk/posh-git/pull/256) is set to `Compact` (see screenshot below).

I noticed there are currently a few other prompt differences as well, such as the `!`/`~` indicators and the fact that the branch name and ahead/behind indicator are a slightly different color that the index/working indicators so they don't blend together when _e. g._ you are ahead and are currently staging another commit.

Would you open to further PRs to resolve these differences? If I were to add something equivalent to the `BranchBehindAndAheadDisplay` setting, would you prefer that be in this PR or a later one?

Thanks for maintaining this project! I like the `posh-git` display a lot and I was very glad to find an alternative for Linux!

![image](https://user-images.githubusercontent.com/4039042/54870782-96f0e380-4d81-11e9-8458-e34133d5370a.png)
