### PR TITLE
Use high-intensity ANSI escapes instead of bold

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -126,40 +126,47 @@ __posh_git_echo () {
         return;
     fi
 
+    local Red='\033[0;31m'
+    local Green='\033[0;32m'
+    local BrightRed='\033[0;91m'
+    local BrightGreen='\033[0;92m'
+    local BrightYellow='\033[0;93m'
+    local BrightCyan='\033[0;96m'
+
     local DefaultForegroundColor=$(__posh_color '\e[m') # Default no color
     local DefaultBackgroundColor=
 
     local BeforeText='['
-    local BeforeForegroundColor=$(__posh_color '\e[1;33m') # Yellow
+    local BeforeForegroundColor=$(__posh_color $BrightYellow) # Yellow
     local BeforeBackgroundColor=
     local DelimText=' |'
-    local DelimForegroundColor=$(__posh_color '\e[1;33m') # Yellow
+    local DelimForegroundColor=$(__posh_color $BrightYellow) # Yellow
     local DelimBackgroundColor=
 
     local AfterText=']'
-    local AfterForegroundColor=$(__posh_color '\e[1;33m') # Yellow
+    local AfterForegroundColor=$(__posh_color $BrightYellow) # Yellow
     local AfterBackgroundColor=
 
-    local BranchForegroundColor=$(__posh_color '\e[1;36m')  # Cyan
+    local BranchForegroundColor=$(__posh_color $BrightCyan)  # Cyan
     local BranchBackgroundColor=
-    local BranchAheadForegroundColor=$(__posh_color '\e[1;32m') # Green
+    local BranchAheadForegroundColor=$(__posh_color $BrightGreen) # Green
     local BranchAheadBackgroundColor=
-    local BranchBehindForegroundColor=$(__posh_color '\e[0;31m') # Red
+    local BranchBehindForegroundColor=$(__posh_color $BrightRed) # Red
     local BranchBehindBackgroundColor=
-    local BranchBehindAndAheadForegroundColor=$(__posh_color '\e[1;33m') # Yellow
+    local BranchBehindAndAheadForegroundColor=$(__posh_color $BrightYellow) # Yellow
     local BranchBehindAndAheadBackgroundColor=
 
     local BeforeIndexText=''
-    local BeforeIndexForegroundColor=$(__posh_color '\e[1;32m') # Dark green
+    local BeforeIndexForegroundColor=$(__posh_color $Green) # Dark green
     local BeforeIndexBackgroundColor=
 
-    local IndexForegroundColor=$(__posh_color '\e[1;32m') # Dark green
+    local IndexForegroundColor=$(__posh_color $Green) # Dark green
     local IndexBackgroundColor=
 
-    local WorkingForegroundColor=$(__posh_color '\e[0;31m') # Dark red
+    local WorkingForegroundColor=$(__posh_color $Red) # Dark red
     local WorkingBackgroundColor=
 
-    local StashForegroundColor=$(__posh_color '\e[0;34m') # Darker blue
+    local StashForegroundColor=$(__posh_color $BrightRed) # Red
     local StashBackgroundColor=
     local BeforeStash='('
     local AfterStash=')'


### PR DESCRIPTION
This matches with the upstream posh-git coloration.

The terminal emulator must support the high-intensity color escapes (_e. g._ `\033[0;92m` for bright green vs. `\033[0;32m` for regular green), but in 2019 I don't anticipate that being a problem. If you want, and you can point me towards an emulator without this support, I'm sure I could add some logic to fall back on using bold instead.

posh-git (upsteam):

![posh-git_colors](https://user-images.githubusercontent.com/4039042/55688049-27aeee00-5942-11e9-84c7-45da02d4f2f2.png)

posh-git-sh (before):

![posh-git-sh_colors_before](https://user-images.githubusercontent.com/4039042/55688000-98a1d600-5941-11e9-9e77-89b680ebaabe.png)

posh-git-sh (after):

![posh-git-sh_colors_after](https://user-images.githubusercontent.com/4039042/55688001-9d668a00-5941-11e9-9203-8a979e89b0db.png)