### PR TITLE
Fix line-wrapping problem

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -210,10 +210,10 @@ __posh_git_echo () {
     local BranchBehindAndAheadStatusSymbol=''
     local BranchWarningStatusSymbol=''
     if $EnableStatusSymbol; then
-      BranchIdenticalStatusSymbol=$' \xE2\x89\xA1' # Three horizontal lines
-      BranchAheadStatusSymbol=$' \xE2\x86\x91' # Up Arrow
-      BranchBehindStatusSymbol=$' \xE2\x86\x93' # Down Arrow
-      BranchBehindAndAheadStatusSymbol=$'\xE2\x86\x95' # Up and Down Arrow
+      BranchIdenticalStatusSymbol=$' \[\xE2\x89\]\xA1' # Three horizontal lines
+      BranchAheadStatusSymbol=$' \[\xE2\x86\]\x91' # Up Arrow
+      BranchBehindStatusSymbol=$' \[\xE2\x86\]\x93' # Down Arrow
+      BranchBehindAndAheadStatusSymbol=$'\[\xE2\x86\]\x95' # Up and Down Arrow
       BranchWarningStatusSymbol=' ?'
     fi
 


### PR DESCRIPTION
### The problem

I had a similar problem to #18 on GNOME Terminal on Red Hat Enterprise Linux 7. If I typed out enough characters to reach the end of the line, the line would wrap back onto the beginning of the *same line* instead of the next line (until I had typed enough characters to reach the end of the line again, then it would wrap onto the next line). I.e. typing the `+` char:
```shell
user@host:~/foo/bar [master ≡ (3)]$ ++++   # EDGE OF WINDOW
```
...continuing to type...
```shell
++++++ost:~/foo/bar [master ≡ (3)]$ +++++++# EDGE OF WINDOW
```

### The solution

The problem was caused by the symbol definitions, e.g. `\xE2\x89\xA1` for the `≡` symbol. As per https://unix.stackexchange.com/a/468983/200655
> Bash cannot calculate the length [of wide unicode symbols] correctly, so easiest way could be to escape 2 out of three parts of those wide symbols.

i.e. `\[\xE2\x89\]\xA1`