### PR TITLE
Show local status summary symbol (! or ~)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The Prompt
 By default, the status summary has the following format:
 
 ```sh
-[{HEAD-name} x +A ~B -C !D | +E ~F -G !H]
+[{HEAD-name} x +A ~B -C !D | +E ~F -G !H W]
 ```
 
 * `{HEAD-name}` is the current branch, or the SHA of a detached HEAD. The color
@@ -82,8 +82,13 @@ By default, the status summary has the following format:
   * `~` modified
   * `-` removed
   * `!` conflicting
+* `W` represents the overall status of the working directory.
+  * `!` there are unstaged changes in the working tree
+  * `~` there are uncommitted changes, i.e. staged changes, in the working tree
+    waiting to be committed
+  * None: there are no unstaged or uncommitted changes to the working tree
 
-For example, a status of `[master ≡ +0 ~2 -1 | +1 ~1 -0]` corresponds to the
+For example, a status of `[master ≡ +0 ~2 -1 | +1 ~1 -0 !]` corresponds to the
 following `git status`:
 
     # On branch master

--- a/git-prompt-test.sh
+++ b/git-prompt-test.sh
@@ -203,20 +203,20 @@ run_test_known_diff empty '[master ?]'
 one_file_unstaged() {
   touch stuff
 }
-run_test_known_diff one_file_unstaged '[master ? +1 ~0 -0]'
+run_test_known_diff one_file_unstaged '[master ? +1 ~0 -0 !]'
 
 one_file_staged() {
   touch stuff
   git add stuff
 }
-run_test_known_diff one_file_staged '[master ? +1 ~0 -0]'
+run_test_known_diff one_file_staged '[master ? +1 ~0 -0 ~]'
 
 one_file_staged_with_unstaged_edit() {
   touch stuff
   git add stuff
   echo stuff > stuff
 }
-run_test_known_diff one_file_staged_with_unstaged_edit '[master ? +1 ~0 -0 | +0 ~1 -0]'
+run_test_known_diff one_file_staged_with_unstaged_edit '[master ? +1 ~0 -0 | +0 ~1 -0 !]'
 
 one_file_typechange() {
   touch file_or_link
@@ -227,7 +227,7 @@ one_file_typechange() {
   rm file_or_link
   ln -s target file_or_link
 }
-run_test_known_diff one_file_typechange '[master ? +0 ~1 -0]'
+run_test_known_diff one_file_typechange '[master ? +0 ~1 -0 !]'
 
 one_file_stashed() {
   touch stuff
@@ -266,7 +266,7 @@ added_edited_deleted_staged_and_unstaged() {
   # unstaged delete
   rm delete_me_2
 }
-run_test_known_diff added_edited_deleted_staged_and_unstaged '[master ? +1 ~1 -1 | +1 ~1 -1]'
+run_test_known_diff added_edited_deleted_staged_and_unstaged '[master ? +1 ~1 -1 | +1 ~1 -1 !]'
 
 # Test summary
 if (( $PASSING_WARNING > 0 || $FAILING_WARNING > 0)); then

--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -171,6 +171,12 @@ __posh_git_echo () {
     local BeforeStash='('
     local AfterStash=')'
 
+    local LocalDefaultStatusSymbol=''
+    local LocalWorkingStatusSymbol=' !'
+    local LocalWorkingStatusColor=$(__posh_color "$Red")
+    local LocalStagedStatusSymbol=' ~'
+    local LocalStagedStatusColor=$(__posh_color "$BrightCyan")
+
     local RebaseForegroundColor=$(__posh_color '\e[0m') # reset
     local RebaseBackgroundColor=
 
@@ -406,10 +412,13 @@ __posh_git_echo () {
         gitstring+="$BranchBackgroundColor$BranchForegroundColor$branchstring$BranchIdenticalStatusSymbol"
     fi
 
+    gitstring+="${rebase:+$RebaseForegroundColor$RebaseBackgroundColor$rebase}"
+
     # index status
     if $EnableFileStatus; then
         local indexCount="$(( $indexAdded + $indexModified + $indexDeleted + $indexUnmerged ))"
         local workingCount="$(( $filesAdded + $filesModified + $filesDeleted + $filesUnmerged ))"
+
         if (( $indexCount != 0 )) || $ShowStatusWhenZero; then
             gitstring+="$IndexBackgroundColor$IndexForegroundColor +$indexAdded ~$indexModified -$indexDeleted"
         fi
@@ -425,11 +434,23 @@ __posh_git_echo () {
         if (( $filesUnmerged != 0 )); then
             gitstring+=" $WorkingBackgroundColor$WorkingForegroundColor!$filesUnmerged"
         fi
-    fi
-    gitstring+="${rebase:+$RebaseForegroundColor$RebaseBackgroundColor$rebase}"
 
-    if $EnableStashStatus && $hasStash; then
-        gitstring+="$DefaultBackgroundColor$DefaultForegroundColor $StashBackgroundColor$StashForegroundColor$BeforeStash$stashCount$AfterStash"
+        local localStatusSymbol=$LocalDefaultStatusSymbol
+        local localStatusColor=$DefaultForegroundColor
+        
+        if (( workingCount != 0 )); then
+            localStatusSymbol=$LocalWorkingStatusSymbol
+            localStatusColor=$LocalWorkingStatusColor
+        elif (( indexCount != 0 )); then
+            localStatusSymbol=$LocalStagedStatusSymbol
+            localStatusColor=$LocalStagedStatusColor
+        fi
+
+        gitstring+="$DefaultBackgroundColor$localStatusColor$localStatusSymbol$DefaultForegroundColor"
+
+        if $EnableStashStatus && $hasStash; then
+            gitstring+="$DefaultBackgroundColor$DefaultForegroundColor $StashBackgroundColor$StashForegroundColor$BeforeStash$stashCount$AfterStash"
+        fi
     fi
 
     # after-branch text


### PR DESCRIPTION
Adds a `!` at the end of the local file status indicators if the repo
has unstaged changes, or a `~` if it has uncommitted (staged) changes
but no unstaged changes.

To achieve greater consistency with upstream posh-git, neither this
symbol nor the stash indicator will appear if `bash.enableFileStatus` is
`false`. Further, the rebase indicator has been moved to _before_ the
file status indicators, and is now immediately adjacent to the branch
name/status. This commit does _not_ change the color of the rebase
indicator, which in posh-git is cyan but in posh-git-sh is currently the
default terminal foreground color.

Resolves #40.