### PR TITLE
Add space before echo to mimic posh-git behavior

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -465,7 +465,7 @@ __posh_git_echo () {
 
     # after-branch text
     gitstring+="$AfterBackgroundColor$AfterForegroundColor$AfterText$DefaultBackgroundColor$DefaultForegroundColor"
-    echo "$gitstring"
+    echo " $gitstring"
 }
 
 # Returns the location of the .git/ directory.


### PR DESCRIPTION
The current implementation requires the prefix to have a space at the end to separate Git information from the rest of the command prompt. Outside of Git repositories, this adds an unnecessary space like this:

`reneschu@ReneSchu:~/repos $`

Adding the space to the git string recreates posh-git's behavior in only adding the space when needed:

`reneschu@ReneSchu:~/repos/test [master ?]$`