### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ Installation Instructions
     For some additional hints for integrating with `oh-my-zsh`, take a look at
     [issue #14](https://github.com/lyze/posh-git-sh/issues/14).
 
+## Installation with Fig
+
+[Fig](https://fig.io) adds apps, shortcuts, and autocomplete to your existing terminal.
+
+Install `posh-git-sh` in just one click.
+
+<a href="https://fig.io/plugins/other/posh-git-sh_lyze" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
 
 The Prompt
 ----------


### PR DESCRIPTION
The [Fig Plugin Store](https://fig.io/plugins) supports 1-click install for 400+ shell plugins. We have over 100k users, thousands of whom manage their shell configuration with Fig.

Posh Git Zsh is already listed in the store so we'd love to have it listed as a download method on your readme.

Thanks so much and please let me know if you have any questions!
