### PR TITLE
Remove unnecessary -z/--null flag from 'git config' call

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -279,7 +279,7 @@ __posh_git_echo () {
 
         b=$(git symbolic-ref HEAD 2>/dev/null) || {
             is_detached=true
-            local output=$(git config -z --get bash.describeStyle)
+            local output=$(git config --get bash.describeStyle)
             if [ -n "$output" ]; then
                 GIT_PS1_DESCRIBESTYLE=$output
             fi


### PR DESCRIPTION
It looks like all references to the variable where the result of this output gets sent to - `$GIT_PS1_DESCRIBESTYLE` - are looking for single words, so they won't miss the null either way.

Fixes #42.