### PR TITLE
Use a literal string for echo in __posh_color to avoid glob expansion.

### DIFF
--- a/git-prompt.sh
+++ b/git-prompt.sh
@@ -145,10 +145,10 @@ __posh_color () {
     if [ -n "$ZSH_VERSION" ]; then
         echo %{$1%}
     elif [ -n "$BASH_VERSION" ]; then
-        echo \\[$1\\]
+        echo '\['$1'\]'
     else
         # assume Bash anyway
-        echo \\[$1\\]
+        echo '\['$1'\]'
     fi
 }
 


### PR DESCRIPTION
Fixes #62.